### PR TITLE
Add the actual message received to the error returned from receiveWelcome()

### DIFF
--- a/client.go
+++ b/client.go
@@ -229,7 +229,7 @@ func (c *Client) receiveWelcome() error {
 		return fmt.Errorf("Error receiving welcome message [%s]: %s", rec, err)
 	}
 	if typ := parseMessageType(rec); typ != msgWelcome {
-		return fmt.Errorf("First message received was not welcome")
+		return fmt.Errorf("First message received was not welcome, instead received: %s", rec)
 	}
 	var msg welcomeMsg
 	err = json.Unmarshal([]byte(rec), &msg)


### PR DESCRIPTION
It is incredibly difficult to debug client connection errors if you can't get at the message that was received from the server.